### PR TITLE
allow to use Rails resolvers as Liquid filesystem

### DIFF
--- a/lib/liquid-rails/resolver_system.rb
+++ b/lib/liquid-rails/resolver_system.rb
@@ -1,0 +1,25 @@
+# Class to be used as a Liquid File System for the `include` tag
+# (so only for liquid partials)
+module Liquid
+  module Rails
+    class ResolverSystem
+      # Return a valid liquid template string for requested partial path
+      def read_template_file(template_path, context)
+        controller_path = context.registers[:controller].controller_path
+        template_path   = "#{controller_path}/#{template_path}" unless template_path.include?('/')
+
+        name = template_path.split('/').last
+        prefix = template_path.split('/')[0...-1].join('/')
+        locale = [context.registers[:controller].locale, :en]
+        # something like {:locale=>[:pl, :en], :formats=>[:html], :variants=>[], :handlers=>[:erb, :builder, :raw, :ruby, :coffee, :jbuilder, :rabl, :liquid], :versions=>[:v10, :v9, :v8, :v7, :v6, :v5, :v4, :v3, :v2, :v1]}
+        details = { locale: locale, formats: [:html], variants: [], handlers: [:liquid], versions:[] }
+        result = context.registers[:controller].view_paths.find_all(name, prefix, partial=true, details)
+        if result.present?
+          result.first.source.force_encoding("UTF-8") # cast to utf8 as it was getting encoding errors
+        else
+          raise FileSystemError, "No such template '#{template_path}'"
+        end
+      end
+    end
+  end
+end

--- a/spec/dummy/vendor/theme/foospace/bar/_partial.liquid
+++ b/spec/dummy/vendor/theme/foospace/bar/_partial.liquid
@@ -1,0 +1,1 @@
+Vendor Theme Bar Partial

--- a/spec/dummy/vendor/theme/home/_partial.liquid
+++ b/spec/dummy/vendor/theme/home/_partial.liquid
@@ -1,0 +1,1 @@
+Vendor Theme Home Partial

--- a/spec/dummy/vendor/theme/shared/_partial.liquid
+++ b/spec/dummy/vendor/theme/shared/_partial.liquid
@@ -1,0 +1,1 @@
+Vendor Theme Shared Partial

--- a/spec/lib/liquid-rails/resolver_system_spec.rb
+++ b/spec/lib/liquid-rails/resolver_system_spec.rb
@@ -1,0 +1,40 @@
+require 'spec_helper'
+require 'liquid-rails/resolver_system'
+
+describe 'Request', type: :feature do
+  context 'render with partial' do
+    before do
+      @original_filesystem = Liquid::Template.file_system
+      Liquid::Template.file_system = Liquid::Rails::ResolverSystem.new
+
+      ApplicationController.class_eval do
+        before_filter :prepend_view_path_if_param_present
+        def prepend_view_path_if_param_present
+          prepend_view_path Rails.root.join('vendor/theme') if params[:prepend_view_path]
+        end
+      end
+    end
+
+    after do
+      Liquid::Template.file_system = @original_filesystem
+    end
+
+    it 'no full path for the current controller' do
+      visit '/index_partial?prepend_view_path=true'
+
+      expect(page.body).to eq("Application Layout\nLiquid on Rails\n\nVendor Theme Home Partial\n\nVendor Theme Shared Partial\n")
+    end
+
+    it 'full path' do
+      visit '/index_partial_with_full_path?prepend_view_path=true'
+
+      expect(page.body).to eq("Application Layout\nLiquid on Rails\n\nVendor Theme Home Partial\n\nVendor Theme Shared Partial\n")
+    end
+
+    it 'respects namespace of original template for partials path' do
+      visit '/foospace/bar/index_partial?prepend_view_path=true'
+
+      expect(page.body.strip).to eq("Foospace::BarController\n\nVendor Theme Bar Partial")
+    end
+  end
+end


### PR DESCRIPTION
In my project I'm using several resolvers, some of them just insert views from external gems and at the front is a panoramic resolver which tries to lookup view from database.
None of above worked for liquid include tag, so I've created another Liquid FileSystem class that will utilize original rails resolvers to fetch proper view.
Right now I haven't set it as a default FileSystem, but I strongly advise for that move.
